### PR TITLE
ci: add PyPI publish workflow with cibuildwheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,84 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: macos-13   # x86_64
+          - os: macos-14   # arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
+          # Linux: use manylinux_2_28 (GLIBC 2.28+); install gfortran 12 from gcc-toolset
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
+          CIBW_BEFORE_ALL_LINUX: dnf install -y gcc-toolset-12-gcc-gfortran lapack-devel blas-devel
+          CIBW_ENVIRONMENT_LINUX: 'FC=/opt/rh/gcc-toolset-12/root/usr/bin/gfortran CMAKE_ARGS="-DIRA_ENABLE_NATIVE_OPTIMIZATION=OFF"'
+          # macOS: install gfortran via Homebrew and create unversioned symlink for CMake
+          CIBW_BEFORE_ALL_MACOS: |
+            brew install gcc
+            GFORTRAN_PATH=$(find "$(brew --prefix gcc)/bin" -name 'gfortran-*' | sort | tail -1)
+            ln -sf "$GFORTRAN_PATH" "$(brew --prefix)/bin/gfortran" || true
+          CIBW_ENVIRONMENT_MACOS: 'CMAKE_ARGS="-DIRA_ENABLE_NATIVE_OPTIMIZATION=OFF"'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish:
+    name: Publish to PyPI
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ira-mod
+    permissions:
+      id-token: write   # required for OIDC trusted publishing
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "wheels-*"
+          path: dist
+          merge-multiple: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ build-backend = "scikit_build_core.build"
 name = "ira_mod"
 dynamic = ["version"]
 description = "Algorithms for Iterative Rotations and Assignments (IRA); Symmetry Operations FInder (SOFI); and Constrained Shortest Distance Assignment (CShDA)."
+readme = "README.md"
+requires-python = ">=3.10"
 authors = [{name = "MAMMASMIAS Consortium"}]
 urls = {Homepage = "https://github.com/mammasmias/IterativeRotationsAssignments"}
 license = {text = "GPL-3.0-or-later OR Apache-2.0"}


### PR DESCRIPTION
Builds binary wheels for Linux (manylinux_2_28/x86_64) and macOS (x86_64 and arm64) for Python 3.10–3.13, plus a source distribution. Publishes to PyPI via OIDC trusted publishing on version tags or manual dispatch. Disables -march=native so wheels are portable.

Also adds readme and requires-python fields to pyproject.toml for correct PyPI package page rendering.





  1. On GitHub — create the environment:
  - Go to repo → Settings → Environments → New environment
  - Name it exactly pypi

  ---
  To publish a new release

  Push a version tag:

  git tag v2.2.0
  git push origin v2.2.0

  The workflow triggers automatically, builds wheels for Linux and macOS, and uploads to PyPI. No tokens or secrets
   needed.

  ---
  Manual publish (without a tag)
  
  Go to the repo → Actions → Publish to PyPI → Run workflow.
